### PR TITLE
CLI: Remove environment.json from compile command

### DIFF
--- a/packages/cli/src/commands/compile.ts
+++ b/packages/cli/src/commands/compile.ts
@@ -2,7 +2,6 @@ import { Command, Flags } from '@oclif/core'
 import { spawnSync } from 'child_process'
 import * as fs from 'fs'
 import * as path from 'path'
-import * as ts from 'typescript'
 
 import log from '../log'
 import ManifestHandler from '../ManifestHandler'
@@ -44,27 +43,8 @@ export default class Compile extends Command {
 
     log.startAction('Saving files')
 
-    const environmentCalls = extractEnvironmentCalls(fs.readFileSync(taskFile, 'utf-8'))
-    fs.writeFileSync(path.join(outputDir, 'environment.json'), JSON.stringify(environmentCalls, null, 2))
     fs.writeFileSync(path.join(outputDir, 'manifest.json'), JSON.stringify(manifest, null, 2))
     log.stopAction()
     console.log(`Build complete! Artifacts in ${outputDir}/`)
   }
-}
-
-function extractEnvironmentCalls(source: string): string[] {
-  const environmentCalls = new Set<string>()
-  const sourceFile = ts.createSourceFile('task.ts', source, ts.ScriptTarget.ES2020, true, ts.ScriptKind.TS)
-  const queue: ts.Node[] = [sourceFile]
-
-  while (queue.length > 0) {
-    const node = queue.pop()!
-    if (ts.isCallExpression(node) && ts.isPropertyAccessExpression(node.expression)) {
-      const { expression, name } = node.expression
-      if (ts.isIdentifier(expression) && expression.escapedText === 'environment')
-        environmentCalls.add(`_${name.escapedText.toString()}`)
-    }
-    queue.push(...node.getChildren())
-  }
-  return Array.from(environmentCalls)
 }

--- a/packages/cli/src/commands/deploy.ts
+++ b/packages/cli/src/commands/deploy.ts
@@ -34,7 +34,7 @@ export default class Deploy extends Command {
         suggestions: ['Use the --input flag to specify the correct path'],
       })
 
-    const neededFiles = ['environment.json', 'manifest.json', 'task.wasm'].map((file) => join(fullInputDir, file))
+    const neededFiles = ['manifest.json', 'task.wasm'].map((file) => join(fullInputDir, file))
     for (const file of neededFiles) {
       if (!fs.existsSync(file))
         this.error(`Could not find ${file}`, {

--- a/packages/cli/tests/commands/compile.spec.ts
+++ b/packages/cli/tests/commands/compile.spec.ts
@@ -31,13 +31,10 @@ describe('compile', () => {
 
           expect(fs.existsSync(`${outputDir}/task.wasm`)).to.be.true
           expect(fs.existsSync(`${outputDir}/task.wat`)).to.be.true
-          expect(fs.existsSync(`${outputDir}/environment.json`)).to.be.true
           expect(fs.existsSync(`${outputDir}/manifest.json`)).to.be.true
 
-          const environment = JSON.parse(fs.readFileSync(`${outputDir}/environment.json`, 'utf-8'))
           const manifest = JSON.parse(fs.readFileSync(`${outputDir}/manifest.json`, 'utf-8'))
 
-          expect(environment).to.be.deep.equal(['_call'])
           expect(manifest.inputs).to.be.deep.equal({ firstStaticNumber: 2, secondStaticNumber: 3 })
         })
       })
@@ -111,7 +108,6 @@ describe('compile', () => {
   context('when the output directory already exists', () => {
     beforeEach('create outputDirectory with files', () => {
       if (!fs.existsSync(outputDir)) fs.mkdirSync(outputDir, { recursive: true })
-      fs.writeFileSync(path.join(outputDir, 'environment.json'), JSON.stringify({ a: 2 }, null, 2))
       fs.writeFileSync(path.join(outputDir, 'randomFile.txt'), JSON.stringify({ a: 2 }, null, 2))
     })
 
@@ -128,13 +124,10 @@ describe('compile', () => {
 
       expect(fs.existsSync(`${outputDir}/task.wasm`)).to.be.true
       expect(fs.existsSync(`${outputDir}/task.wat`)).to.be.true
-      expect(fs.existsSync(`${outputDir}/environment.json`)).to.be.true
       expect(fs.existsSync(`${outputDir}/manifest.json`)).to.be.true
 
-      const environment = JSON.parse(fs.readFileSync(`${outputDir}/environment.json`, 'utf-8'))
       const manifest = JSON.parse(fs.readFileSync(`${outputDir}/manifest.json`, 'utf-8'))
 
-      expect(environment).to.be.deep.equal(['_call'])
       expect(manifest.inputs).to.be.deep.equal({ firstStaticNumber: 2, secondStaticNumber: 3 })
     })
   })

--- a/packages/cli/tests/commands/deploy.spec.ts
+++ b/packages/cli/tests/commands/deploy.spec.ts
@@ -32,7 +32,7 @@ describe('deploy', () => {
         let axiosMock: MockAdapter
 
         beforeEach('create files', () => {
-          ;['environment.json', 'manifest.json', 'task.wasm'].map(createFile)
+          ;['manifest.json', 'task.wasm'].map(createFile)
         })
 
         beforeEach('create axios mock', () => {
@@ -108,15 +108,15 @@ describe('deploy', () => {
 
       context('when the directory does not contain the necessary files', () => {
         context('when the directory contains no files', () => {
-          itThrowsACliError(command, `Could not find ${inputDir}/environment.json`, 'FileNotFound', 1)
+          itThrowsACliError(command, `Could not find ${inputDir}/manifest.json`, 'FileNotFound', 1)
         })
 
         context('when the directory contains only one file', () => {
           beforeEach('create file', () => {
-            createFile('environment.json')
+            createFile('manifest.json')
           })
 
-          itThrowsACliError(command, `Could not find ${inputDir}/manifest.json`, 'FileNotFound', 1)
+          itThrowsACliError(command, `Could not find ${inputDir}/task.wasm`, 'FileNotFound', 1)
         })
       })
     })


### PR DESCRIPTION
All environment functions must be injected from the runner. Those that are not called in the task will simply be ignored in the execution.