### PR TITLE
CLI: Fix mimic init

### DIFF
--- a/packages/cli/src/templates/package.json
+++ b/packages/cli/src/templates/package.json
@@ -8,7 +8,9 @@
     "build": "mimic compile"
   },
   "devDependencies": {
-    "assemblyscript": "^0.27.31",
-    "typescript": "^5.5.4"
+    "typescript": "^5.8.3",
+    "assemblyscript": "0.27.36",
+    "json-as": "1.0.7",
+    "visitor-as": "0.11.4"
   }
 }

--- a/packages/cli/src/templates/src/task.ts
+++ b/packages/cli/src/templates/src/task.ts
@@ -1,13 +1,11 @@
-import { Address, BigInt, Bytes, environment, NULL_ADDRESS } from '@mimicprotocol/lib-ts'
+import { Address, BigInt, Bytes, CallData, environment, NULL_ADDRESS } from '@mimicprotocol/lib-ts'
 
 export default function main(): void {
-  const settler = Address.fromString(NULL_ADDRESS)
-  const chainId = 1
   const target = Address.fromString(NULL_ADDRESS)
   const data = Bytes.empty()
   const feeToken = Address.fromString(NULL_ADDRESS)
   const feeAmount = BigInt.zero()
 
   // Replace this with your task code
-  environment.call(settler, chainId, target, feeToken, feeAmount, data)
+  environment.call([new CallData(target, data)], feeToken, feeAmount)
 }

--- a/packages/lib-ts/package.json
+++ b/packages/lib-ts/package.json
@@ -10,12 +10,12 @@
     "lint": "eslint . --ignore-pattern 'src/environment.ts' --ignore-pattern 'src/evm.ts'"
   },
   "devDependencies": {
-    "@as-pect/cli": "^8.1.0",
-    "assemblyscript": "^0.27.35"
+    "@as-pect/cli": "8.1.0",
+    "assemblyscript": "0.27.36"
   },
   "dependencies": {
     "eslint-config-mimic": "^0.0.3",
-    "json-as": "^1.0.7",
-    "visitor-as": "^0.11.4"
+    "json-as": "1.0.7",
+    "visitor-as": "0.11.4"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -37,7 +37,7 @@
   resolved "https://registry.yarnpkg.com/@as-pect/assembly/-/assembly-8.1.0.tgz#788ad200e2eec36e6fc158c5cf65932faca18671"
   integrity sha512-ALDm5M0Zx/hoFZ27vS3/kjkzMHbcPt2IBIkNjJz0M798meRCJV6ZWbChfmi4kDcMqaPk/awU54b4Bpx+VxBKfg==
 
-"@as-pect/cli@^8.1.0":
+"@as-pect/cli@8.1.0":
   version "8.1.0"
   resolved "https://registry.yarnpkg.com/@as-pect/cli/-/cli-8.1.0.tgz#5120560142a636d9de00783854e8f86c4938a30f"
   integrity sha512-bu2PUnWdYcF3aQ7X9rB6GXiE+b7Pi0MGMOyiShqdGlDCr3vKoD1kAK5Kb5rqY3tWRCC4gWO7/wupEynem6Qq0Q==
@@ -2232,6 +2232,14 @@ asn1@~0.2.3:
   dependencies:
     safer-buffer "~2.1.0"
 
+assemblyscript@0.27.36:
+  version "0.27.36"
+  resolved "https://registry.yarnpkg.com/assemblyscript/-/assemblyscript-0.27.36.tgz#5ff7ae6c3047e96b13de32d4dc741f256d33943f"
+  integrity sha512-1qX2zf6p7l/mNYv8r21jC/Yft7kX7XKR3xUHw41zvV4xad5lyC8w7jZiwZBGoy64VKZLc+bTDJDWi8Kb70YrHA==
+  dependencies:
+    binaryen "116.0.0-nightly.20240114"
+    long "^5.2.4"
+
 assemblyscript@^0.27.2:
   version "0.27.31"
   resolved "https://registry.yarnpkg.com/assemblyscript/-/assemblyscript-0.27.31.tgz#07412b1bc42c67f78080dbaddca030ab74d3b9b2"
@@ -2239,14 +2247,6 @@ assemblyscript@^0.27.2:
   dependencies:
     binaryen "116.0.0-nightly.20240114"
     long "^5.2.1"
-
-assemblyscript@^0.27.35:
-  version "0.27.36"
-  resolved "https://registry.yarnpkg.com/assemblyscript/-/assemblyscript-0.27.36.tgz#5ff7ae6c3047e96b13de32d4dc741f256d33943f"
-  integrity sha512-1qX2zf6p7l/mNYv8r21jC/Yft7kX7XKR3xUHw41zvV4xad5lyC8w7jZiwZBGoy64VKZLc+bTDJDWi8Kb70YrHA==
-  dependencies:
-    binaryen "116.0.0-nightly.20240114"
-    long "^5.2.4"
 
 assert-plus@1.0.0, assert-plus@^1.0.0:
   version "1.0.0"
@@ -5009,7 +5009,7 @@ jsbn@~0.1.0:
   resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.1.tgz#a5e654c2e5a2deb5f201d96cefbca80c0ef2f513"
   integrity sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg==
 
-json-as@^1.0.7:
+json-as@1.0.7:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/json-as/-/json-as-1.0.7.tgz#2bfdbf5d01bd6bf35984b969caf2317372bb2df3"
   integrity sha512-+SOoMPj+HOB7RR7KO8gDKOPFlUyp4ltOHcJRrSLHLZmvhhw9330kSrTEycIppCX+tHhbqDu8slX32c4T4mq6Ng==
@@ -7916,7 +7916,7 @@ verror@1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
-visitor-as@^0.11.4:
+visitor-as@0.11.4, visitor-as@^0.11.4:
   version "0.11.4"
   resolved "https://registry.yarnpkg.com/visitor-as/-/visitor-as-0.11.4.tgz#7b2d7b7ac8be86d4741796aa0630af5e471a4744"
   integrity sha512-uih7AooY2V3LhzobjLqyEQzhYYBGeq0y/rZk295foM1Ko498f24NNXBDyM1SgzcLMFCAT/fpmSRco1BpTIdKNQ==


### PR DESCRIPTION
Fix mimic init by updating the dependencies in the template and fixing the task

I removed the ^ version prefix from AssemblyScript-related packages. AssemblyScript and related tooling (e.g. json-as) often introduce breaking changes even in patch releases, so pinning exact versions provides more stability.

The root cause was that the main yarn.lock had json-as@1.0.7, while the demo task (which lacks a yarn.lock) would resolve to json-as@1.1.6, leading to runtime incompatibilities.

<img width="775" alt="Screenshot 2025-05-27 at 17 39 40" src="https://github.com/user-attachments/assets/d741ed07-ad62-4901-a11d-8e250630f7e0" />

 
