### PR TITLE
Tests: Fix optional timestamp

### DIFF
--- a/packages/test-ts/src/run-task.ts
+++ b/packages/test-ts/src/run-task.ts
@@ -61,7 +61,7 @@ function generateMock(params: GenerateMockParams): MockConfig {
   const decodeResponse: Record<string, string> = {}
   if (calls.length > 0) {
     for (const { to, chainId, timestamp, data, output, outputType } of calls) {
-      const key = JSON.stringify({ to, chainId, timestamp: timestamp || null, data })
+      const key = JSON.stringify({ to, chainId, ...(timestamp && { timestamp }), data })
       callResponse[key] = output
       const decodeKey = JSON.stringify({ abiType: outputType, value: output })
       decodeResponse[decodeKey] = output


### PR DESCRIPTION
The library doesn't send `timestamp` as `null`; it simply omits the property.  
Our mocks were including `timestamp: null`, which didn’t match the actual behavior and caused mismatches with what the runner expects.